### PR TITLE
Fixed unauthorized handling

### DIFF
--- a/src/Utils/NotificationUtils.ts
+++ b/src/Utils/NotificationUtils.ts
@@ -95,8 +95,12 @@ export default class NotificationUtils {
      */
     public showNotLoggedInMessage(serverUrl: string) {
         if (this.useDialogInsteadOfNewWindow) {
-            this.showInfoBanner(`Please log into <a id="login-link">Teamscale</a>`);
-            $('#login-link').click(() => this.showLoginDialog(serverUrl));
+            const message: string = `Please log into <a class="login-link" data-ts-url="${encodeURIComponent(serverUrl)}"> Teamscale</a>`;
+            if (this.showInfoBanner(message)) {
+                // do not add listener twice
+                $(`.login-link[data-ts-url="${encodeURIComponent(serverUrl)}"]`).on('click',
+                    () => this.showLoginDialog(serverUrl));
+            }
         } else {
             this.showInfoBanner(`Please log into <a href="${serverUrl}" target="_blank">Teamscale</a> and repeat.`);
         }
@@ -105,29 +109,36 @@ export default class NotificationUtils {
     /**
      * Shows an info banner (vss notification).
      * @param message The message to display. It may contain HTML.
+     * @return True, if banner was added. False, otherwise.
      */
-    public showInfoBanner(message: string) {
-        this.showBanner(message, this.notificationService.MessageAreaType.Info);
+    public showInfoBanner(message: string): boolean {
+        return this.showBanner(message, this.notificationService.MessageAreaType.Info);
     }
 
     /**
      * Shows an error banner (vss notification).
      * @param message The message to display. It may contain HTML.
+     * @return True, if banner was added. False, otherwise.
      */
-    public showErrorBanner(message: string) {
-        this.showBanner(message, this.notificationService.MessageAreaType.Error);
+    public showErrorBanner(message: string): boolean {
+        return this.showBanner(message, this.notificationService.MessageAreaType.Error);
     }
 
-    private showBanner(message: string, bannerType: any) {
+    /**
+     * Adds an info or error banner.
+     * @return True, if banner was added. False, otherwise.
+     */
+    private showBanner(message: string, bannerType: any): boolean {
         const notificationContainer = $('#message-div');
         if (notificationContainer.html().includes(message)) {
             // do not display the same message more than once
-            return;
+            return false;
         }
 
         const notification = this.generateNotification();
         notification.setMessage($(`<div>${message}</div>`), bannerType);
         UiUtils.resizeHost();
+        return true;
     }
 
     /**

--- a/src/Utils/ProjectsUtils.ts
+++ b/src/Utils/ProjectsUtils.ts
@@ -8,6 +8,8 @@ import NotificationUtils from './NotificationUtils';
 
 export enum BadgeType { TestGap, FindingsChurn }
 
+export const NOT_AUTHORIZED_ERROR = 'Not authorized for Teamscale usage. Please log in.';
+
 export async function resolveProjectNameByIssueId(teamscaleClient: TeamscaleClient, projectCandidates: string[],
                                                   issueId: number, notificationUtils: NotificationUtils,
                                                   badgeType: BadgeType): Promise<string> {
@@ -50,7 +52,7 @@ export async function resolveProjectNameByIssueId(teamscaleClient: TeamscaleClie
     if (validProjects.length === 0) {
         if (errorCodeSum > 0 && (errorCodeSum % 401 === 0 || errorCodeSum % 403 === 0)) {
             notificationUtils.handleErrorInTeamscaleCommunication({status: 403}, teamscaleClient.url);
-            return;
+            throw new Error(NOT_AUTHORIZED_ERROR);
         }
 
         notificationUtils.showErrorBanner('None of the configured Teamscale projects (' + projectCandidates.join(',') +

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "teamscale-azure-devops-plugin",
     "publisher": "CQSEGmbH",
-    "version": "0.0.837",
+    "version": "0.0.860",
     "name": "Teamscale DevOps",
     "description": "Teamscale Integration with Azure DevOps",
     "public": false,


### PR DESCRIPTION
If one was not authenticated to the TS server, next to the "please log in" message
an information was shown that the ADOS=>TS project mapping should be checked (no
TS project seemed to be appropriate due to no access to the TS server).
This was fixed in this commit, only the "please log in" message is now shown.