### PR TITLE
Fix TGA project resolution

### DIFF
--- a/src/ITgaIssueQueryPercentage.d.ts
+++ b/src/ITgaIssueQueryPercentage.d.ts
@@ -1,14 +1,9 @@
 /**
  * Format of Teamscale TGA issue query percentage object.
  */
+import { ITgaSummary } from './ITgaSummary';
 
 export interface ITgaIssueQueryPercentage {
     issueIdToStatistics: any;
-    summary: {
-        testGapRatio: number;
-        untestedAddedMethodsRatio: number;
-        untestedChangedMethodsRatio: number;
-        numberOfTestGaps: number;
-        numberOfChangedMethods: number;
-    };
+    summary: ITgaSummary;
 }

--- a/src/ITgaSummary.d.ts
+++ b/src/ITgaSummary.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Format of Teamscale TGA summary object.
+ */
+
+export interface ITgaSummary {
+    testGapRatio: number;
+    untestedAddedMethodsRatio: number;
+    untestedChangedMethodsRatio: number;
+    numberOfTestGaps: number;
+    numberOfChangedMethods: number;
+}

--- a/src/TeamscaleClient.ts
+++ b/src/TeamscaleClient.ts
@@ -6,6 +6,7 @@ import { IFindingsChurnList } from './IFindingsChurnList';
 import { ITeamscaleBaseline } from './ITeamscaleBaseline';
 import { ITeamscaleBranchesInfo } from './ITeamscaleBranchesInfo';
 import { ITgaIssueQueryPercentage } from './ITgaIssueQueryPercentage';
+import { ITgaSummary } from './ITgaSummary';
 
 export default class TeamscaleClient {
     constructor(public readonly url: string) {
@@ -68,6 +69,17 @@ export default class TeamscaleClient {
         const xhr = this.generateRequest(
             'GET', `/p/${project}/issue-finding-churn/${issueId}`);
         const promise = this.generatePromise<string>(xhr).then(findingsChurnList => JSON.parse(findingsChurnList));
+        xhr.send();
+        return promise;
+    }
+
+    /**
+     * Retrieves the an TGA issue percentage object for a single issue.
+     */
+    public retrieveTgaSummaryForIssue(project: string, issueId: string): PromiseLike<ITgaSummary> {
+        const xhr = this.generateRequest(
+            'GET', `/api/projects/${project}/issues/${encodeURIComponent(issueId)}/tga-summary`);
+        const promise = this.generatePromise<string>(xhr).then(tgaSummary => JSON.parse(tgaSummary));
         xhr.send();
         return promise;
     }

--- a/src/Utils/ProjectsUtils.ts
+++ b/src/Utils/ProjectsUtils.ts
@@ -65,7 +65,7 @@ export async function resolveProjectNameByIssueId(teamscaleClient: TeamscaleClie
     return validProjects[0];
 }
 
-/*
+/**
  * Wrapper (needed since API changed with TS 5.5) method to get the Test Gap summary for an issue; tries both API calls.
  */
 async function getTestGapSummary(teamscaleClient: TeamscaleClient, projectCandidate, issueId: number): Promise<ITgaSummary> {

--- a/src/WorkItemFormExtension/WorkItemContribution.ts
+++ b/src/WorkItemFormExtension/WorkItemContribution.ts
@@ -196,8 +196,13 @@ async function resolveProjectNames() {
             ProjectUtils.BadgeType.FindingsChurn, 'Findings Churn');
     }
 
+    let tgaProjectsSettingsKey = Settings.TGA_TEAMSCALE_PROJECTS_KEY;
+    if (!useExtraTgaConfiguration) {
+        tgaProjectsSettingsKey = Settings.TEAMSCALE_PROJECTS_KEY;
+    }
+
     if (showTestGapBadge) {
-        tgaTeamscaleProject = await resolveProjectName(tgaTeamscaleClient, Settings.TGA_TEAMSCALE_PROJECTS_KEY,
+        tgaTeamscaleProject = await resolveProjectName(tgaTeamscaleClient, tgaProjectsSettingsKey,
             ProjectUtils.BadgeType.TestGap, 'Test Gap');
     }
 }


### PR DESCRIPTION
* Project resolution currently always uses TGA project configuration, but should only if separate TGA config is enabled
* With TS 5.5 an API change was introduced, which requires the call also adapted in the ADOS plugin