### PR TITLE
TS-38194: Remove usages of legacy API

### DIFF
--- a/src/ITeamscaleBranchesInfo.d.ts
+++ b/src/ITeamscaleBranchesInfo.d.ts
@@ -3,10 +3,9 @@
  */
 
 export interface ITeamscaleBranchesInfo {
-    mainBranchName: string;
-    branchNames: string[];
+    liveBranches: string[];
     deletedBranches: string[];
     anonymousBranches: string[];
-    aliases: any;
-
+    virtualBranches: string[];
+    currentBranchesCount: number;
 }

--- a/src/ITgaIssueQueryPercentage.d.ts
+++ b/src/ITgaIssueQueryPercentage.d.ts
@@ -1,9 +1,0 @@
-/**
- * Format of Teamscale TGA issue query percentage object.
- */
-import { ITgaSummary } from './ITgaSummary';
-
-export interface ITgaIssueQueryPercentage {
-    issueIdToStatistics: any;
-    summary: ITgaSummary;
-}

--- a/src/TeamscaleClient.ts
+++ b/src/TeamscaleClient.ts
@@ -41,7 +41,7 @@ export default class TeamscaleClient {
     public queryFindingsChurnBadge(project: string, issueId: number): PromiseLike<string> {
         project = encodeURIComponent(project);
         const xhr = this.generateRequest(
-            'GET', `api/v5.9/projects/${project}/issues/${issueId}/findings-badge`, IMAGE_SVG);
+            'GET', `/api/v5.9/projects/${project}/issues/${issueId}/findings-badge`, IMAGE_SVG);
         return this.wrapWithIssueIdLink(xhr, project, issueId);
     }
 
@@ -66,7 +66,7 @@ export default class TeamscaleClient {
     public retrieveFindingsDeltaBadge(project: string, startTimestamp: number): PromiseLike<string> {
         project = encodeURIComponent(project);
         const xhr = this.generateRequest(
-            'GET', `api/v5.9/projects/${project}/findings/delta/badge?t1=${startTimestamp}&t2=HEAD`, IMAGE_SVG);
+            'GET', `/api/v5.9/projects/${project}/findings/delta/badge?t1=${startTimestamp}&t2=HEAD`, IMAGE_SVG);
         const promise = this.generatePromise<string>(xhr).then(badge => {
             const findingsDeltaLink = `${this.url}/delta.html#findings/${project}/?from=${startTimestamp}&to=HEAD`;
             return `<a href="${findingsDeltaLink}" target="_top">${badge}</a>`;

--- a/src/Utils/ProjectsUtils.ts
+++ b/src/Utils/ProjectsUtils.ts
@@ -68,7 +68,7 @@ export async function resolveProjectNameByIssueId(teamscaleClient: TeamscaleClie
  * Returns true if the client returns test gap for the given project candidate and issue id.
  */
 async function hasTestGapFindings(teamscaleClient: TeamscaleClient, projectCandidate: string, issueId: number): Promise<boolean> {
-    const testGapSummary: ITgaSummary = await getTestGapSummary(teamscaleClient, projectCandidate, issueId);
+    const testGapSummary: ITgaSummary = await teamscaleClient.retrieveTgaSummaryForIssue(projectCandidate, issueId);
 
     return testGapSummary && testGapSummary.numberOfChangedMethods > 0;
 }
@@ -91,7 +91,7 @@ async function hasTestSmellFindings(teamscaleClient: TeamscaleClient, projectCan
  * Returns true if the client returns findings churn for the given project candidate and issue id.
  */
 async function hasFindingsChurn(teamscaleClient: TeamscaleClient, projectCandidate: string, issueId: number): Promise<boolean> {
-    const findingsChurnList = await teamscaleClient.retrieveFindingsChurnListForIssue(projectCandidate, issueId.toString());
+    const findingsChurnList = await teamscaleClient.retrieveFindingsChurnListForIssue(projectCandidate, issueId);
     
     return findingsChurnList.addedFindings && findingsChurnList.addedFindings.length > 0 ||
         findingsChurnList.findingsInChangedCode && findingsChurnList.findingsInChangedCode.length > 0 ||
@@ -112,22 +112,6 @@ export async function retrieveRequirementsConnectorId(teamscaleClient: Teamscale
         }
     }
     return connectorId;
-}
-
-/**
- * Wrapper (needed since API changed with TS 5.5) method to get the Test Gap summary for an issue; tries both API calls.
- */
-async function getTestGapSummary(teamscaleClient: TeamscaleClient, projectCandidate, issueId: number): Promise<ITgaSummary> {
-    try {
-        return await teamscaleClient.retrieveTgaSummaryForIssue(projectCandidate, issueId.toString());
-    } catch (reason) {
-        if (reason && reason.status && reason.status === 404) {
-            // reason for 404 can be a non-existing project or Teamscale API with version < 5.5
-            return (await teamscaleClient.retrieveTgaPercentagesForIssue(projectCandidate, issueId.toString())).summary;
-        }
-
-        throw reason;
-    }
 }
 
 /**


### PR DESCRIPTION
I had to raise the minimum required API version to 7.1 (see project Ids request). Because of this, I could remove the fallback to the "/p/${project}/tga-issue-query-percentage/" service, which does not exist anymore